### PR TITLE
extent result pagination to 100.

### DIFF
--- a/kadasrouting/core/datacatalogueclient.py
+++ b/kadasrouting/core/datacatalogueclient.py
@@ -85,6 +85,7 @@ class DataCatalogueClient(QObject):
         query = QUrlQuery()
         url = QUrl(f"{self.url}/search")
         query.addQueryItem("q", self.search_str)
+        query.addQueryItem("num", "100")
         query.addQueryItem("f", "pjson")
         url.setQuery(query.query())
         response = QgsNetworkAccessManager.blockingGet(QNetworkRequest(QUrl(url)))


### PR DESCRIPTION
The default amount of results called for the data catalogue is 10 by default. Extend this value to 100.